### PR TITLE
Fix typo of carrier as career

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## About The Project
 
-Welcome to the Phone plugin repository, the right solution for introducing modern communication features to your Minecraft server. This plugin revolutionizes player interaction by bringing contacts, calls, and careers directly into the game from a phone item.
+Welcome to the Phone plugin repository, the right solution for introducing modern communication features to your Minecraft server. This plugin revolutionizes player interaction by bringing contacts, calls, and carriers directly into the game from a phone item.
 
 ## Getting Started
 

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/MenuCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/MenuCommand.java
@@ -37,7 +37,7 @@ public class MenuCommand implements SubCommand {
                             return;
                         }
 
-                        new PhoneMenu(contacts, sim.career()).open(player);
+                        new PhoneMenu(contacts, sim.carrier()).open(player);
                     });
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/MessageCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/MessageCommand.java
@@ -56,7 +56,7 @@ public class MessageCommand implements SubCommand {
                     return;
                 }
 
-                Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.career());
+                Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.carrier());
                 boolean enabled = PhonePlugin.getInstance().getConfig().getBoolean("repeater-enabled", true);
                 if (enabled &&
                         (nearestRepeater == null || nearestRepeater.range() < player.getLocation().distance(nearestRepeater.location()))) {

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/RenewCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/RenewCommand.java
@@ -19,7 +19,7 @@ public class RenewCommand implements SubCommand {
         }
 
         if (PhonePlugin.getInstance().getConfig().getConfigurationSection("careers." + args[2].toLowerCase()) == null) {
-            player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-career"));
+            player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-carrier"));
             return;
         }
 

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/RenewCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/RenewCommand.java
@@ -18,7 +18,7 @@ public class RenewCommand implements SubCommand {
             return;
         }
 
-        if (PhonePlugin.getInstance().getConfig().getConfigurationSection("careers." + args[2].toLowerCase()) == null) {
+        if (PhonePlugin.getInstance().getConfig().getConfigurationSection("carriers." + args[2].toLowerCase()) == null) {
             player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-carrier"));
             return;
         }

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/RepeaterCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/RepeaterCommand.java
@@ -36,7 +36,7 @@ public class RepeaterCommand implements SubCommand {
             return;
         }
 
-        if (PhonePlugin.getInstance().getConfig().getConfigurationSection("careers." + args[3].toLowerCase()) == null) {
+        if (PhonePlugin.getInstance().getConfig().getConfigurationSection("carriers." + args[3].toLowerCase()) == null) {
             player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-carrier"));
             return;
         }

--- a/src/main/java/me/michelemanna/phone/commands/subcommands/RepeaterCommand.java
+++ b/src/main/java/me/michelemanna/phone/commands/subcommands/RepeaterCommand.java
@@ -37,7 +37,7 @@ public class RepeaterCommand implements SubCommand {
         }
 
         if (PhonePlugin.getInstance().getConfig().getConfigurationSection("careers." + args[3].toLowerCase()) == null) {
-            player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-career"));
+            player.sendMessage(PhonePlugin.getInstance().getMessage("commands.invalid-carrier"));
             return;
         }
 
@@ -51,7 +51,7 @@ public class RepeaterCommand implements SubCommand {
             nbt.setBoolean("repeater", true);
             nbt.setInteger("speed", speed);
             nbt.setInteger("range", range);
-            nbt.setString("career", args[3].toLowerCase());
+            nbt.setString("carrier", args[3].toLowerCase());
         });
 
         player.getInventory().addItem(repeater);

--- a/src/main/java/me/michelemanna/phone/conversations/PlayerMessageConversation.java
+++ b/src/main/java/me/michelemanna/phone/conversations/PlayerMessageConversation.java
@@ -45,7 +45,7 @@ public class PlayerMessageConversation extends StringPrompt {
                 return;
             }
 
-            Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.career());
+            Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.carrier());
             boolean enabled = PhonePlugin.getInstance().getConfig().getBoolean("repeater-enabled", true);
 
             if (enabled &&

--- a/src/main/java/me/michelemanna/phone/data/Repeater.java
+++ b/src/main/java/me/michelemanna/phone/data/Repeater.java
@@ -8,13 +8,13 @@ public class Repeater {
     private final Location location;
     private final int speed;
     private final int range;
-    private final String career;
+    private final String carrier;
 
-    public Repeater(Location location, int speed, int range, String career) {
+    public Repeater(Location location, int speed, int range, String carrier) {
         this.location = location;
         this.speed = speed;
         this.range = range;
-        this.career = career;
+        this.carrier = carrier;
     }
 
     public int speed() {
@@ -29,20 +29,20 @@ public class Repeater {
         return range;
     }
 
-    public String career() {
-        return career;
+    public String carrier() {
+        return carrier;
     }
 
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Repeater repeater = (Repeater) o;
-        return speed == repeater.speed && range == repeater.range && Objects.equals(location, repeater.location) && Objects.equals(career, repeater.career);
+        return speed == repeater.speed && range == repeater.range && Objects.equals(location, repeater.location) && Objects.equals(carrier, repeater.carrier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(location, speed, range, career);
+        return Objects.hash(location, speed, range, carrier);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class Repeater {
                 "location=" + location +
                 ", speed=" + speed +
                 ", range=" + range +
-                ", career='" + career + '\'' +
+                ", carrier='" + carrier + '\'' +
                 '}';
     }
 }

--- a/src/main/java/me/michelemanna/phone/data/Sim.java
+++ b/src/main/java/me/michelemanna/phone/data/Sim.java
@@ -5,12 +5,12 @@ import java.util.Objects;
 public final class Sim {
     private final int messagesSent;
     private final long lastRenew;
-    private final String career;
+    private final String carrier;
 
-    public Sim(int messagesSent, long lastRenew, String career) {
+    public Sim(int messagesSent, long lastRenew, String carrier) {
         this.messagesSent = messagesSent;
         this.lastRenew = lastRenew;
-        this.career = career;
+        this.carrier = carrier;
     }
 
     public int messagesSent() {
@@ -21,20 +21,20 @@ public final class Sim {
         return lastRenew;
     }
 
-    public String career() {
-        return career;
+    public String carrier() {
+        return carrier;
     }
 
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Sim sim = (Sim) o;
-        return messagesSent == sim.messagesSent && lastRenew == sim.lastRenew && Objects.equals(career, sim.career);
+        return messagesSent == sim.messagesSent && lastRenew == sim.lastRenew && Objects.equals(carrier, sim.carrier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(messagesSent, lastRenew, career);
+        return Objects.hash(messagesSent, lastRenew, carrier);
     }
 
     @Override
@@ -42,7 +42,7 @@ public final class Sim {
         return "Sim{" +
                 "messagesSent=" + messagesSent +
                 ", lastRenew=" + lastRenew +
-                ", career='" + career + '\'' +
+                ", carrier='" + carrier + '\'' +
                 '}';
     }
 }

--- a/src/main/java/me/michelemanna/phone/gui/PhoneMenu.java
+++ b/src/main/java/me/michelemanna/phone/gui/PhoneMenu.java
@@ -21,14 +21,14 @@ import java.util.*;
 public class PhoneMenu implements InventoryHolder {
     private static final Map<Player, ItemStack[]> INVENTORIES = new HashMap<>();
     private final List<Contact> contacts = new ArrayList<>();
-    private final String career;
+    private final String carrier;
     private final Map<Integer, AbstractItem> items = new HashMap<>();
     private int page = 0;
     private Inventory inventory;
 
-    public PhoneMenu(List<Contact> contacts, String career) {
+    public PhoneMenu(List<Contact> contacts, String carrier) {
         this.contacts.addAll(contacts);
-        this.career = career;
+        this.carrier = carrier;
     }
 
     public void open(Player player) {
@@ -110,7 +110,7 @@ public class PhoneMenu implements InventoryHolder {
 
         Repeater nearest = PhonePlugin.getInstance()
                 .getRepeaterManager()
-                .getNearest(player.getLocation(), career);
+                .getNearest(player.getLocation(), carrier);
 
         if (nearest == null) {
             return new ItemBuilder(Material.MAP)

--- a/src/main/java/me/michelemanna/phone/gui/items/ContactItem.java
+++ b/src/main/java/me/michelemanna/phone/gui/items/ContactItem.java
@@ -58,7 +58,7 @@ public class ContactItem extends AbstractItem {
                 return;
             }
 
-            if (System.currentTimeMillis() - sim.lastRenew() > 1000*60*60*24*PhonePlugin.getInstance().getConfig().getLong("careers." + sim.carrier() + ".duration")) {
+            if (System.currentTimeMillis() - sim.lastRenew() > 1000*60*60*24*PhonePlugin.getInstance().getConfig().getLong("carriers." + sim.carrier() + ".duration")) {
                 player.sendMessage(PhonePlugin.getInstance().getMessage("gui.phone-expired"));
                 return;
             }
@@ -71,7 +71,7 @@ public class ContactItem extends AbstractItem {
 
             switch (clickType) {
                 case LEFT:
-                    if (sim.messagesSent() >= PhonePlugin.getInstance().getConfig().getLong("careers." + sim.carrier() + ".messages")) {
+                    if (sim.messagesSent() >= PhonePlugin.getInstance().getConfig().getLong("carriers." + sim.carrier() + ".messages")) {
                         player.sendMessage(PhonePlugin.getInstance().getMessage("gui.no-messages"));
                         return;
                     }

--- a/src/main/java/me/michelemanna/phone/gui/items/ContactItem.java
+++ b/src/main/java/me/michelemanna/phone/gui/items/ContactItem.java
@@ -58,20 +58,20 @@ public class ContactItem extends AbstractItem {
                 return;
             }
 
-            if (System.currentTimeMillis() - sim.lastRenew() > 1000*60*60*24*PhonePlugin.getInstance().getConfig().getLong("careers." + sim.career() + ".duration")) {
+            if (System.currentTimeMillis() - sim.lastRenew() > 1000*60*60*24*PhonePlugin.getInstance().getConfig().getLong("careers." + sim.carrier() + ".duration")) {
                 player.sendMessage(PhonePlugin.getInstance().getMessage("gui.phone-expired"));
                 return;
             }
 
             if (PhonePlugin.getInstance().getConfig().getBoolean("repeater-enabled", true) &&
-                    !PhonePlugin.getInstance().getRepeaterManager().isNear(player.getLocation(), sim.career())) {
+                    !PhonePlugin.getInstance().getRepeaterManager().isNear(player.getLocation(), sim.carrier())) {
                 player.sendMessage(PhonePlugin.getInstance().getMessage("gui.no-signal"));
                 return;
             }
 
             switch (clickType) {
                 case LEFT:
-                    if (sim.messagesSent() >= PhonePlugin.getInstance().getConfig().getLong("careers." + sim.career() + ".messages")) {
+                    if (sim.messagesSent() >= PhonePlugin.getInstance().getConfig().getLong("careers." + sim.carrier() + ".messages")) {
                         player.sendMessage(PhonePlugin.getInstance().getMessage("gui.no-messages"));
                         return;
                     }

--- a/src/main/java/me/michelemanna/phone/hooks/PhonePlaceholder.java
+++ b/src/main/java/me/michelemanna/phone/hooks/PhonePlaceholder.java
@@ -36,9 +36,9 @@ public class PhonePlaceholder extends PlaceholderExpansion {
                 Repeater nearest = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation());
                 return nearest == null ? "N/A" : String.valueOf(Math.round(nearest.location().distance(player.getLocation())));
             }
-            case "career":
-                String career = PhonePlugin.getInstance().getDatabase().getCareersCache().get(player.getUniqueId());
-                return career == null ? "N/A" : career;
+            case "carrier":
+                String carrier = PhonePlugin.getInstance().getDatabase().getCareersCache().get(player.getUniqueId());
+                return carrier == null ? "N/A" : carrier;
             case "connection": {
                 Repeater nearest = PhonePlugin.getInstance()
                         .getRepeaterManager()

--- a/src/main/java/me/michelemanna/phone/listeners/PlayerListener.java
+++ b/src/main/java/me/michelemanna/phone/listeners/PlayerListener.java
@@ -53,7 +53,7 @@ public class PlayerListener implements Listener {
                             return;
                         }
 
-                        new PhoneMenu(contacts, sim.career()).open(event.getPlayer());
+                        new PhoneMenu(contacts, sim.carrier()).open(event.getPlayer());
                     });
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/src/main/java/me/michelemanna/phone/listeners/RepeaterListener.java
+++ b/src/main/java/me/michelemanna/phone/listeners/RepeaterListener.java
@@ -34,11 +34,11 @@ public class RepeaterListener implements Listener {
             int range = NBT.get(item, nbt -> {
                 return nbt.getInteger("range");
             });
-            String career = NBT.get(item, nbt -> {
-                return nbt.getString("career");
+            String carrier = NBT.get(item, nbt -> {
+                return nbt.getString("carrier");
             });
 
-            PhonePlugin.getInstance().getRepeaterManager().addRepeater(event.getBlock().getLocation(), speed, range, career);
+            PhonePlugin.getInstance().getRepeaterManager().addRepeater(event.getBlock().getLocation(), speed, range, carrier);
 
             event.setCancelled(true);
 

--- a/src/main/java/me/michelemanna/phone/managers/CallManager.java
+++ b/src/main/java/me/michelemanna/phone/managers/CallManager.java
@@ -57,7 +57,7 @@ public class CallManager implements ICallManager {
                 return;
             }
 
-            Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.career());
+            Repeater nearestRepeater = PhonePlugin.getInstance().getRepeaterManager().getNearest(player.getLocation(), sim.carrier());
 
             boolean enabled = PhonePlugin.getInstance().getConfig().getBoolean("repeater-enabled", true);
             if (enabled &&

--- a/src/main/java/me/michelemanna/phone/managers/DatabaseManager.java
+++ b/src/main/java/me/michelemanna/phone/managers/DatabaseManager.java
@@ -76,18 +76,18 @@ public class DatabaseManager {
         });
     }
 
-    public void renewCareer(UUID owner, String career) {
+    public void renewCareer(UUID owner, String carrier) {
         Bukkit.getScheduler().runTaskAsynchronously(PhonePlugin.getInstance(), () -> {
             try {
                 Connection connection = provider.getConnection();
-                PreparedStatement statement = connection.prepareStatement("UPDATE phoneNumbers SET lastRenew = ?, messageCount = ?, career = ? WHERE owner = ?");
+                PreparedStatement statement = connection.prepareStatement("UPDATE phoneNumbers SET lastRenew = ?, messageCount = ?, carrier = ? WHERE owner = ?");
 
                 statement.setLong(1, System.currentTimeMillis());
                 statement.setInt(2, 0);
-                statement.setString(3, career);
+                statement.setString(3, carrier);
                 statement.setString(4, owner.toString());
 
-                careersCache.put(owner, career);
+                careersCache.put(owner, carrier);
 
                 statement.executeUpdate();
                 statement.close();
@@ -104,12 +104,12 @@ public class DatabaseManager {
         Bukkit.getScheduler().runTaskAsynchronously(PhonePlugin.getInstance(), () -> {
             try {
                 Connection connection = provider.getConnection();
-                PreparedStatement statement = connection.prepareStatement("SELECT lastRenew, messageCount, career FROM phoneNumbers WHERE owner = ?");
+                PreparedStatement statement = connection.prepareStatement("SELECT lastRenew, messageCount, carrier FROM phoneNumbers WHERE owner = ?");
 
                 statement.setString(1, owner.toString());
 
                 ResultSet set = statement.executeQuery();
-                future.complete(set.next() ? new Sim(set.getInt("messageCount"), set.getLong("lastRenew"), set.getString("career")) : null);
+                future.complete(set.next() ? new Sim(set.getInt("messageCount"), set.getLong("lastRenew"), set.getString("carrier")) : null);
 
                 statement.close();
                 provider.closeConnection(connection);
@@ -260,7 +260,7 @@ public class DatabaseManager {
                 List<Repeater> locations = new ArrayList<>();
 
                 while (set.next()) {
-                    locations.add(new Repeater(new Location(Bukkit.getWorld(set.getString("world")), set.getInt("x"), set.getInt("y"), set.getInt("z")), set.getInt("speed"), set.getInt("range"), set.getString("career")));
+                    locations.add(new Repeater(new Location(Bukkit.getWorld(set.getString("world")), set.getInt("x"), set.getInt("y"), set.getInt("z")), set.getInt("speed"), set.getInt("range"), set.getString("carrier")));
                 }
 
                 future.complete(locations);
@@ -276,11 +276,11 @@ public class DatabaseManager {
         return future;
     }
 
-    public void addRepeater(Location location, int speed, int range, String career) {
+    public void addRepeater(Location location, int speed, int range, String carrier) {
         Bukkit.getScheduler().runTaskAsynchronously(PhonePlugin.getInstance(), () -> {
             try {
                 Connection connection = provider.getConnection();
-                PreparedStatement statement = connection.prepareStatement("INSERT INTO repeaters (x, y, z, world, speed, `range`, career) VALUES (?, ?, ?, ?, ?, ?, ?)");
+                PreparedStatement statement = connection.prepareStatement("INSERT INTO repeaters (x, y, z, world, speed, `range`, carrier) VALUES (?, ?, ?, ?, ?, ?, ?)");
 
                 statement.setInt(1, location.getBlockX());
                 statement.setInt(2, location.getBlockY());
@@ -288,7 +288,7 @@ public class DatabaseManager {
                 statement.setString(4, location.getWorld().getName());
                 statement.setInt(5, speed);
                 statement.setInt(6, range);
-                statement.setString(7, career);
+                statement.setString(7, carrier);
 
                 statement.executeUpdate();
                 statement.close();
@@ -323,7 +323,7 @@ public class DatabaseManager {
         Bukkit.getScheduler().runTaskAsynchronously(PhonePlugin.getInstance(), () -> {
             try {
                 Connection connection = provider.getConnection();
-                PreparedStatement statement = connection.prepareStatement("SELECT number, career FROM phoneNumbers WHERE owner = ?");
+                PreparedStatement statement = connection.prepareStatement("SELECT number, carrier FROM phoneNumbers WHERE owner = ?");
 
                 statement.setString(1, owner.toString());
 
@@ -331,8 +331,8 @@ public class DatabaseManager {
                 if (set.next()) {
                     numbersCache.put(owner, set.getLong("number"));
 
-                    if (set.getString("career") != null) {
-                        careersCache.put(owner, set.getString("career"));
+                    if (set.getString("carrier") != null) {
+                        careersCache.put(owner, set.getString("carrier"));
                     }
                 }
 

--- a/src/main/java/me/michelemanna/phone/managers/RepeaterManager.java
+++ b/src/main/java/me/michelemanna/phone/managers/RepeaterManager.java
@@ -15,9 +15,9 @@ public class RepeaterManager {
         PhonePlugin.getInstance().getDatabase().getRepeaters().thenAccept(repeaters::addAll);
     }
 
-    public void addRepeater(Location location, int speed, int range, String career) {
-        repeaters.add(new Repeater(location, speed, range, career));
-        PhonePlugin.getInstance().getDatabase().addRepeater(location, speed, range, career);
+    public void addRepeater(Location location, int speed, int range, String carrier) {
+        repeaters.add(new Repeater(location, speed, range, carrier));
+        PhonePlugin.getInstance().getDatabase().addRepeater(location, speed, range, carrier);
     }
 
     public void removeRepeater(Location location) {
@@ -29,14 +29,14 @@ public class RepeaterManager {
         return repeaters.stream().anyMatch(repeater -> repeater.location().equals(location));
     }
 
-    public boolean isNear(Location location, String career) {
+    public boolean isNear(Location location, String carrier) {
         return repeaters.stream()
-                .anyMatch(repeater -> repeater.location().getWorld().equals(location.getWorld()) && repeater.location().distance(location) <= repeater.range() && repeater.career().equals(career));
+                .anyMatch(repeater -> repeater.location().getWorld().equals(location.getWorld()) && repeater.location().distance(location) <= repeater.range() && repeater.carrier().equals(carrier));
     }
 
-    public Repeater getNearest(Location location, String career) {
+    public Repeater getNearest(Location location, String carrier) {
         return repeaters.stream()
-                .filter(repeater -> repeater.location().getWorld().equals(location.getWorld()) && repeater.career().equals(career))
+                .filter(repeater -> repeater.location().getWorld().equals(location.getWorld()) && repeater.carrier().equals(carrier))
                 .min(Comparator.comparingDouble(repeater -> repeater.location().distance(location)))
                 .orElse(null);
     }

--- a/src/main/java/me/michelemanna/phone/managers/providers/MySQLProvider.java
+++ b/src/main/java/me/michelemanna/phone/managers/providers/MySQLProvider.java
@@ -89,10 +89,10 @@ public class MySQLProvider implements ConnectionProvider {
             String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("careers").getKeys(false).iterator().next();
 
             statement.execute(
-                    "ALTER TABLE repeaters ADD COLUMN career VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"
+                    "ALTER TABLE repeaters ADD COLUMN carrier VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"
             );
             statement.execute(
-              "ALTER TABLE phoneNumbers ADD COLUMN career VARCHAR(36) DEFAULT NULL"
+              "ALTER TABLE phoneNumbers ADD COLUMN carrier VARCHAR(36) DEFAULT NULL"
             );
             PhonePlugin.getInstance().getConfig().set("version", 3);
             PhonePlugin.getInstance().saveConfig();

--- a/src/main/java/me/michelemanna/phone/managers/providers/MySQLProvider.java
+++ b/src/main/java/me/michelemanna/phone/managers/providers/MySQLProvider.java
@@ -86,7 +86,7 @@ public class MySQLProvider implements ConnectionProvider {
         }
 
         if (PhonePlugin.getInstance().getConfig().getInt("version", 0) <= 2) {
-            String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("careers").getKeys(false).iterator().next();
+            String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("carriers").getKeys(false).iterator().next();
 
             statement.execute(
                     "ALTER TABLE repeaters ADD COLUMN carrier VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"

--- a/src/main/java/me/michelemanna/phone/managers/providers/SQLiteProvider.java
+++ b/src/main/java/me/michelemanna/phone/managers/providers/SQLiteProvider.java
@@ -62,10 +62,10 @@ public class SQLiteProvider implements ConnectionProvider {
             String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("careers").getKeys(false).iterator().next();
 
             statement.execute(
-                    "ALTER TABLE repeaters ADD COLUMN career VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"
+                    "ALTER TABLE repeaters ADD COLUMN carrier VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"
             );
             statement.execute(
-                    "ALTER TABLE phoneNumbers ADD COLUMN career VARCHAR(36) DEFAULT NULL"
+                    "ALTER TABLE phoneNumbers ADD COLUMN carrier VARCHAR(36) DEFAULT NULL"
             );
             PhonePlugin.getInstance().getConfig().set("version", 3);
             PhonePlugin.getInstance().saveConfig();

--- a/src/main/java/me/michelemanna/phone/managers/providers/SQLiteProvider.java
+++ b/src/main/java/me/michelemanna/phone/managers/providers/SQLiteProvider.java
@@ -59,7 +59,7 @@ public class SQLiteProvider implements ConnectionProvider {
         );
 
         if (PhonePlugin.getInstance().getConfig().getInt("version", 0) <= 2) {
-            String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("careers").getKeys(false).iterator().next();
+            String defaultCareer = PhonePlugin.getInstance().getConfig().getConfigurationSection("carriers").getKeys(false).iterator().next();
 
             statement.execute(
                     "ALTER TABLE repeaters ADD COLUMN carrier VARCHAR(36) NOT NULL DEFAULT '" + defaultCareer + "'"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,9 +34,9 @@ messages:
       - "&f/phone menu &8»&f Open the phone menu"
       - "&f/phone number <player> &8»&f Retrieve a player's phone number"
       - "&f/phone regen <player> &8»&f Generate a new phone number"
-      - "&f/phone renew <player> <career> &8»&f Renew the phone subscription"
+      - "&f/phone renew <player> <carrier> &8»&f Renew the phone subscription"
       - "&f/phone whois <number> &8»&f Check who is the owner of a number"
-      - "&f/phone repeater <speed> <range> <career> &8»&f Get a repeater item"
+      - "&f/phone repeater <speed> <range> <carrier> &8»&f Get a repeater item"
       - "&f/phone message <number> <message> &8»&f Send a message to a player"
       - "&f/phone call <number> &8»&f Call a player"
       - "&f/phone accept &8»&f Accept a call"
@@ -61,16 +61,16 @@ messages:
     regen-usage: "&8» &cUsage: /phone regen <player>"
     phone-regenerated: "&8» &7You have regenerated the phone of &e&n%player%"
 
-    renew-usage: "&8» &cUsage: /phone renew <player> <career>"
+    renew-usage: "&8» &cUsage: /phone renew <player> <carrier>"
     invalid-number: "&8» &cInvalid phone number"
-    invalid-career: "&8» &cInvalid career"
+    invalid-carrier: "&8» &cInvalid carrier"
     phone-renewed: "&8» &7You have renewed the phone."
 
     whois-usage: "&8» &cUsage: /phone whois <number>"
     whois: "&8» &aThe phone number &e&n%number% &ais owned by &e%player%"
 
     repeater-given: "&8» &7You have received a repeater"
-    repeater-usage: "&8» &cUsage: /phone repeater <speed> <range> <career>"
+    repeater-usage: "&8» &cUsage: /phone repeater <speed> <range> <carrier>"
     repeater-disabled: "&8» &cThe repeater is disabled"
     invalid-arguments: "&8» &cInvalid argument"
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,7 +13,7 @@ resourcepack:
   enabled: true
   url: "https://github.com/Michelo11/Phone/releases/download/v2.0.4/Custom.Phone.zip"
 
-careers:
+carriers:
   example:
     messages: 100
     duration: 30


### PR DESCRIPTION
This PR should fix the typo of carrier as career. I'm not 100% sure if it works, but it should since I have used a regex pattern to replace it everywhere in the repo from ``career`` to ``carrier``.

That being said, this would still require change on the documentation at https://phone.michelemanna.me, but this seems doable since it's not too much.